### PR TITLE
创建一个 bundle 文件文件名错误

### DIFF
--- a/src/content/guides/getting-started.md
+++ b/src/content/guides/getting-started.md
@@ -167,7 +167,7 @@ __dist/index.html__
    </head>
    <body>
 -    <script src="./src/index.js"></script>
-+    <script src="main.js"></script>
++    <script src="bundle.js"></script>
    </body>
   </html>
 ```


### PR DESCRIPTION
在'创建一个 bundle 文件'小节内  
  dist/index.html 的 <script>标签src 应该是 'bundle.js' 而不是 'main.js'