### PR TITLE
remove  webpack.optimize.UglifyJsPlugin

### DIFF
--- a/src/content/concepts/index.md
+++ b/src/content/concepts/index.md
@@ -134,7 +134,6 @@ const config = {
     ]
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
     new HtmlWebpackPlugin({template: './src/index.html'})
   ]
 };


### PR DESCRIPTION
webpack4.x had removed this plugin

[压缩](https://webpack.js.org/configuration/optimization/#optimization-minimize)

替换成了
`optimization: {
    minimize: false
  }`

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
