### PR TITLE
Update output-management.md

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -210,7 +210,7 @@ __webpack.config.js__
       print: './src/print.js'
     },
     plugins: [
-+     new CleanWebpackPlugin(['dist']),
++     new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
         title: 'Output Management'
       })


### PR DESCRIPTION
after clean-webpack-plugin@2.0   ;

   use     ` new CleanWebpackPlugin()`  instead of  `new CleanWebpackPlugin(['dist'])`

> By default, this plugin will remove all files inside webpack's output.path directory, as well as all unused webpack assets after every successful rebuild. 
from [https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional](url)

_describe your changes..._

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
