### PR TITLE
Update babel-loader.md

### DIFF
--- a/src/content/loaders/babel-loader.md
+++ b/src/content/loaders/babel-loader.md
@@ -6,9 +6,11 @@ repo: https://github.com/babel/babel-loader
 ---
 
 
-这个包允许你使用 [Babel](https://github.com/babel/babel) 和 [webpack](https://github.com/webpack/webpack) 转换 `JavaScript` 文件。
 
-__注意:__ 若有问题请上报至 Babel [issue tracker](https://github.com/babel/babel/issues).
+
+此 package 允许你使用 [Babel](https://github.com/babel/babel) 和 [webpack](https://github.com/webpack/webpack) 转译 `JavaScript` 文件。
+
+**注意**：请在 Babel [Issues](https://github.com/babel/babel/issues) tracker 上报告输出时遇到的问题。
 
 ## 中文文档
 
@@ -24,15 +26,15 @@ npm install -D babel-loader @babel/core @babel/preset-env webpack
 
 ## 用法
 
-[文档：使用 loader](https://webpack.js.org/loaders/)
+webpack 文档：[loaders](https://webpack.js.org/loaders/)
 
-在 webpack 配置对象中，需要添加 babel-loader 到 module 的 loaders 列表中，像下面这样：
+在 webpack 配置对象中，需要将 babel-loader 添加到 module 列表中，就像下面这样：
 
 ```javascript
 module: {
   rules: [
     {
-      test: /\.js$/,
+      test: /\.m?js$/,
       exclude: /(node_modules|bower_components)/,
       use: {
         loader: 'babel-loader',
@@ -45,18 +47,17 @@ module: {
 }
 ```
 
-## 配置
+## 选项
 
-参考 `babel` [配置/选项](https://babeljs.io/docs/usage/api/#options)。
+查看 `babel` [选项](https://babel.docschina.org/docs/en/options)。
 
-
-你可以使用 [options 属性](https://webpack.js.org/configuration/module/#rule-options-rule-query) 来给 loader 传递选项：
+你可以使用 [`options`](https://webpack.js.org/configuration/module/#rule-options-rule-query) 属性，来向 loader 传递 options 选项：
 
 ```javascript
 module: {
   rules: [
     {
-      test: /\.js$/,
+      test: /\.m?js$/,
       exclude: /(node_modules|bower_components)/,
       use: {
         loader: 'babel-loader',
@@ -70,42 +71,44 @@ module: {
 }
 ```
 
-此 loader 也支持下面这些 loader 特定(loader-specific)的配置选项：
+此 loader 也支持下面这些 loader 特有的选项：
 
-* `cacheDirectory`：默认值为 `false`。当有设置时，指定的目录将用来缓存 loader 的执行结果。之后的 webpack 构建，将会尝试读取缓存，来避免在每次执行时，可能产生的、高性能消耗的 Babel 重新编译过程(recompilation process)。如果设置了一个空值 (`loader: 'babel-loader?cacheDirectory`) 或者 `true` (`loader: babel-loader?cacheDirectory=true`)，loader 将使用默认的缓存目录 `node_modules/.cache/babel-loader`，如果在任何根目录下都没有找到 `node_modules` 目录，将会降级回退到操作系统默认的临时文件目录。
-* `cacheIdentifier`：默认是一个由 `@babel/core` 的版本号，`babel-loader` 的版本号，`.babelrc` 文件内容（存在的情况下），环境变量 `BABEL_ENV` 的值（没有时降级到 `NODE_ENV`）组成的字符串。可以设置为一个自定义的值，在 identifier 改变后，强制缓存失效。
-* `cacheCompression`：默认值为 `true`。当有设置时，每个Babel转换输出将使用Gzip压缩。如果你想要退出缓存压缩，将它设置为 `false` -- 如果您的项目转换成数千个文件，您的项目可能会从中得到好处。
-* `customize`: 默认为 `null`。导出 `custom` 回调的文件路径，[就像(下文中)传递`.custom()`那样](#customized-loader)(相关内容见下文[自定义 loader])。由于你必须创建一个新文件才能使用它，建议你使用 `.custom` 来创建一个包装loader. 只有在你必须继续直接使用`babel-loader`但又想自定义的情况下才使用这项配置。
+* `cacheDirectory`：默认值为 `false`。当有设置时，指定的目录将用来缓存 loader 的执行结果。之后的 webpack 构建，将会尝试读取缓存，来避免在每次执行时，可能产生的、高性能消耗的 Babel 重新编译过程(recompilation process)。如果设置了一个空值 (`loader: 'babel-loader?cacheDirectory'`) 或者 `true` (`loader: 'babel-loader?cacheDirectory=true'`)，loader 将使用默认的缓存目录 `node_modules/.cache/babel-loader`，如果在任何根目录下都没有找到 `node_modules` 目录，将会降级回退到操作系统默认的临时文件目录。
+
+* `cacheIdentifier`：默认是由 `@babel/core` 版本号，`babel-loader` 版本号，`.babelrc` 文件内容（存在的情况下），环境变量 `BABEL_ENV` 的值（没有时降级到 `NODE_ENV`）组成的一个字符串。可以设置为一个自定义的值，在 identifier 改变后，来强制缓存失效。
+
+* `cacheCompression`：默认值为 `true`。当设置此值时，会使用 Gzip 压缩每个 Babel transform 输出。如果你想要退出缓存压缩，将它设置为 `false` -- 如果你的项目中有数千个文件需要压缩转译，那么设置此选项可能会从中收益。
+
+* `customize`: 默认值为 `null`。导出 `custom` 回调函数的模块路径，[例如传入 `.custom()` 的 callback 函数](#自定义-loader)。由于你必须创建一个新文件才能使用它，建议改为使用 `.custom` 来创建一个包装 loader。只有在你_必须_继续直接使用 `babel-loader` 但又想自定义的情况下，才使用这项配置。
 
 ## 疑难解答
 
 ### babel-loader 很慢！
 
-确保转译尽可能少的文件。你可能使用 `/\.js$/` 来匹配，这样也许会去转译 `node_modules` 目录或者其他不需要的源代码。
+确保转译尽可能少的文件。你可能使用 `/\.m?js$/` 来匹配，这样也许会去转译 `node_modules` 目录或者其他不需要的源代码。
 
 要排除 `node_modules`，参考文档中的 `loaders` 配置的 `exclude` 选项。
 
-你也可以通过使用 `cacheDirectory` 选项，将 babel-loader 提速至少两倍。
-这会将转译的结果缓存到文件系统中。
+你也可以通过使用 `cacheDirectory` 选项，将 babel-loader 提速至少两倍。这会将转译的结果缓存到文件系统中。
 
-### babel 在每个文件都插入了辅助代码，使代码体积过大！
+### Babel 在每个文件都插入了辅助代码，使代码体积过大！
 
-babel 对一些公共方法使用了非常小的辅助代码，比如 `_extend`。
-默认情况下会被添加到每一个需要它的文件中
+Babel 对一些公共方法使用了非常小的辅助代码，比如 `_extend`。默认情况下会被添加到每一个需要它的文件中
 
-你可以引入 babel runtime 作为一个独立模块，来避免重复引入。
+你可以引入 Babel runtime 作为一个独立模块，来避免重复引入。
 
-下面的配置禁用了 babel 自动对每个文件的 runtime 注入，而是引入 `@babel/plugin-transform-runtime` 并且使所有辅助代码从这里引用。
+下面的配置禁用了 Babel 自动对每个文件的 runtime 注入，而是引入 `@babel/plugin-transform-runtime` 并且使所有辅助代码从这里引用。
 
-更多信息请参考[文档](http://babeljs.io/docs/plugins/transform-runtime/)。
+更多信息请查看 [文档](https://babel.docschina.org/docs/en/babel-plugin-transform-runtime/)。
 
-**注意：** 你必须执行 `npm install -D @babel/plugin-transform-runtime` 来把它包含到你的项目中，也要使用 `npm install @babel/runtime` 把 `@babel/runtime` 安装为一个依赖。
+**注意**：你必须执行 `npm install -D @babel/plugin-transform-runtime` 来把它包含到你的项目中，然后使用 `npm install @babel/runtime` 把 `@babel/runtime` 安装为一个依赖。
 
 ```javascript
 rules: [
-  // 'transform-runtime' 插件告诉 babel 要引用 runtime 来代替注入。
+  // 'transform-runtime' 插件告诉 Babel
+  // 要引用 runtime 来代替注入。
   {
-    test: /\.js$/,
+    test: /\.m?js$/,
     exclude: /(node_modules|bower_components)/,
     use: {
       loader: 'babel-loader',
@@ -118,9 +121,9 @@ rules: [
 ]
 ```
 
-#### **注意：** transform-runtime 和自定义 polyfills (比如 Promise library)
+#### **注意**：transform-runtime 和自定义 polyfills (例如 Promise library)
 
-由于 [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) 包含了一个 polyfill，含有自定义的 [regenerator runtime](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) 和 [core.js](https://github.com/zloirock/core-js), 下面使用 `webpack.ProvidePlugin` 来配置 shimming 的常用方法将没有作用：
+由于 [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) 包含了一个 polyfill，含有自定义的 [regenerator-runtime](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) 和 [core-js](https://github.com/zloirock/core-js), 下面使用 `webpack.ProvidePlugin` 来配置 shimming 的常用方法将没有作用：
 
 ```javascript
 // ...
@@ -150,9 +153,9 @@ require('@babel/runtime/core-js/promise')['default'] = require('bluebird');
 var promise = new _Promise();
 ```
 
-前面的 `Promise` 库在被覆盖前已经被引用和使用了。
+前面的 `Promise` library 在被覆盖前已经被引用和使用了。
 
-一种可行的办法是，在你的应用中加入一个“启动器(bootstrap)”步骤，在应用开始前先覆盖默认的全局变量。
+一种可行的办法是，在你的应用程序中加入一个“引导(bootstrap)”步骤，在应用程序开始前先覆盖默认的全局变量。
 
 ```javascript
 // bootstrap.js
@@ -164,43 +167,44 @@ require('@babel/runtime/core-js/promise').default = require('bluebird');
 require('./app');
 ```
 
-### `babel` 的 node API 已经被移到 `babel-core` 中。
+### `babel` 的 Node.js API 已经被移到 `babel-core` 中。（原文：The Node.js API for `babel` has been moved to `babel-core`.）
 
-(原文：The Node.js API for `babel` has been moved to `babel-core`.)
-
-如果你收到这个信息，这说明你有一个已经安装的 `babel` 包，并且在 webpack 配置中使用它来作为 loader 的简写 (这样的方式在 webpack 2.x 版本中将不再被支持)。
-
-```js
+如果你收到这个信息，这说明你有一个已经安装的 `babel` npm package，并且在 webpack 配置中使用 loader 简写方式（在 webpack 2.x 版本中将不再支持这种方式）。
+```javascript
   {
-    test: /\.js$/,
+    test: /\.m?js$/,
     loader: 'babel',
   }
 ```
 
-webpack 将尝试读取 `babel` 包而不是 `babel-loader`。
+webpack 将尝试读取 `babel` package 而不是 `babel-loader`。
 
-要修复这个问题，你需要删除 `babel` npm 包，因为它在 babel v6 中已经被废除。(安装 `@babel/cli` 或者 `@babel/core` 来替代它)。
-
-如果你的依赖中有对 `babel` 包的依赖使你无法删除它，可以在 webpack 配置中使用完整的 loader 名称来解决：
-```js
+想要修复这个问题，你需要卸载 `babel` npm package，因为它在 Babel v6 中已经被废除。（安装 `@babel/cli` 或者 `@babel/core` 来替代它）
+在另一种场景中，如果你的依赖于 `babel` 而无法删除它，可以在 webpack 配置中使用完整的 loader 名称来解决：
+```javascript
   {
-    test: /\.js$/,
+    test: /\.m?js$/,
     loader: 'babel-loader',
   }
 ```
 
 ## 自定义 loader
 
-`babel-loader` 提供了一个loader-builder实用程序，允许用户对"Babel处理的每个文件"添加自定义处理配置项。
+`babel-loader` 提供了一个 loader-builder 工具函数，
+允许用户为 Babel 处理过的每个文件添加自定义处理选项。
 
-`.custom` 接收一个回调，它将被 `babel` 实例本身的loader调用，因此，工具能够完全确保它使用和`@babel/core` 完全相同的实例作为它自己的loader。
+`.custom` 接收一个 callback 函数，
+它将被调用，并传入 loader 中的 `babel` 实例，
+因此，此工具函数才能够完全确保它使用与 loader 的 `@babel/core` 相同的实例。
 
-如果你想自定义而不是调用一个名叫 `.custom` 的文件，你也可以使用某个导出了你的`custom`回调函数的文件，给 `customize` 配置传一个字符串类型的文件名称。
+如果你想自定义，但实际上某个文件又不想调用 `.custom`，
+可以向 `customize` 选项传入一个字符串，
+此字符串指向一个导出 `custom` 回调函数的文件。
 
 ### 示例
 
 ```js
-// 从"./my-custom-loader.js"或者任何你想要的文件名导出
+// 从 "./my-custom-loader.js" 中导出，或者任何你想要的文件中导出。
 module.exports = require("babel-loader").custom(babel => {
   function myPlugin() {
     return {
@@ -209,18 +213,18 @@ module.exports = require("babel-loader").custom(babel => {
   }
 
   return {
-    // 提供这个loader的配置.
+    // 传给 loader 的选项。
     customOptions({ opt1, opt2, ...loader }) {
       return {
-        // loader可能具有的任何自定义配置
+        // 获取 loader 可能会有的自定义选项
         custom: { opt1, opt2 },
 
-        // "移除了两个自定义配置"的配置
+        // 传入"移除了两个自定义选项"后的选项
         loader,
       };
     },
 
-    // 提供Babel的'PartialConfig'对象
+    // 提供 Babel 的 'PartialConfig' 对象
     config(cfg) {
       if (cfg.hasFilesystemConfig()) {
         // 使用正常的配置
@@ -232,7 +236,7 @@ module.exports = require("babel-loader").custom(babel => {
         plugins: [
           ...(cfg.options.plugins || []),
 
-          // 在配置中包含自定义plugin
+          // 在选项中包含自定义 plugin
           myPlugin,
         ],
       };
@@ -249,7 +253,7 @@ module.exports = require("babel-loader").custom(babel => {
 ```
 
 ```js
-// 然后在你的Webpack config文件中
+// 然后，在你的 webpack config 文件中
 module.exports = {
   // ..
   module: {
@@ -264,16 +268,20 @@ module.exports = {
 
 ### `customOptions(options: Object): { custom: Object, loader: Object }`
 
-指定的loader的配置选项，从`babel-loader`中分离出自定义选项。
+指定的 loader 的选项，
+从 `babel-loader` 选项中分离出自定义选项。
+
 
 ### `config(cfg: PartialConfig): Object`
 
-指定的Babel `PartialConfig` 对象，返回应该被传递给 `babel.transform` 的 `option` 对象。
+指定的 Babel 的 `PartialConfig` 对象，
+返回应该被传递给 `babel.transform` 的 `option` 对象。
+
 
 ### `result(result: Result): Result`
 
-指定的Babel结果对象，允许loaders对它进行额外的调整。
+指定的 Babel 结果对象，允许 loaders 对它进行额外的调整。
+
 
 ## License
-
 [MIT](https://couto.mit-license.org/)

--- a/src/content/loaders/babel-loader.md
+++ b/src/content/loaders/babel-loader.md
@@ -6,9 +6,9 @@ repo: https://github.com/babel/babel-loader
 ---
 
 
-This package allows transpiling JavaScript files using [Babel](https://github.com/babel/babel) and [webpack](https://github.com/webpack/webpack).
+这个包允许你使用 [Babel](https://github.com/babel/babel) 和 [webpack](https://github.com/webpack/webpack) 转换 `JavaScript` 文件。
 
-__Notes:__ Issues with the output should be reported on the babel [issue tracker](https://github.com/babel/babel/issues).
+__注意:__ 若有问题请上报至 Babel [issue tracker](https://github.com/babel/babel/issues).
 
 ## 中文文档
 
@@ -16,16 +16,10 @@ __Notes:__ Issues with the output should be reported on the babel [issue tracker
 
 ## 安装
 
-> webpack 3.x | babel-loader 8.x | babel 7.x
+> webpack 4.x | babel-loader 8.x | babel 7.x
 
 ```bash
-npm install babel-loader@8.0.0-beta.0 @babel/core @babel/preset-env webpack
-```
-
-> webpack 3.x babel-loader 7.x | babel 6.x
-
-```bash
-npm install babel-loader babel-core babel-preset-env webpack
+npm install -D babel-loader @babel/core @babel/preset-env webpack
 ```
 
 ## 用法
@@ -51,9 +45,9 @@ module: {
 }
 ```
 
-##
+## 配置
 
-参考 `babel` [选项](https://babeljs.io/docs/usage/api/#options)。
+参考 `babel` [配置/选项](https://babeljs.io/docs/usage/api/#options)。
 
 
 你可以使用 [options 属性](https://webpack.js.org/configuration/module/#rule-options-rule-query) 来给 loader 传递选项：
@@ -68,7 +62,7 @@ module: {
         loader: 'babel-loader',
         options: {
           presets: ['@babel/preset-env'],
-          plugins: [require('@babel/plugin-transform-object-rest-spread')]
+          plugins: ['@babel/plugin-proposal-object-rest-spread']
         }
       }
     }
@@ -76,15 +70,12 @@ module: {
 }
 ```
 
-此 loader 也支持下面这些 loader 特定(loader-specific)的选项：
+此 loader 也支持下面这些 loader 特定(loader-specific)的配置选项：
 
-* `cacheDirectory`：默认值为 `false`。当有设置时，指定的目录将用来缓存 loader 的执行结果。之后的 webpack 构建，将会尝试读取缓存，来避免在每次执行时，可能产生的、高性能消耗的 Babel 重新编译过程(recompilation process)。如果设置了一个空值 (`loader: 'babel-loader?cacheDirectory'`) 或者 `true` (`loader: babel-loader?cacheDirectory=true`)，loader 将使用默认的缓存目录 `node_modules/.cache/babel-loader`，如果在任何根目录下都没有找到 `node_modules` 目录，将会降级回退到操作系统默认的临时文件目录。
-
-* `cacheIdentifier`：默认是一个由 babel-core 版本号，babel-loader 版本号，.babelrc 文件内容（存在的情况下），环境变量 `BABEL_ENV` 的值（没有时降级到 `NODE_ENV`）组成的字符串。可以设置为一个自定义的值，在 identifier 改变后，强制缓存失效。
-
-* `forceEnv`：默认将解析 BABEL_ENV 然后是 NODE_ENV。允许你在 loader 级别上覆盖 BABEL_ENV/NODE_ENV。对有不同 babel 配置的，客户端和服务端同构应用非常有用。
-
-__注意：__`sourceMap` 选项是被忽略的。当 webpack 配置了 sourceMap 时（通过 `devtool` 配置选项），将会自动生成 sourceMap。
+* `cacheDirectory`：默认值为 `false`。当有设置时，指定的目录将用来缓存 loader 的执行结果。之后的 webpack 构建，将会尝试读取缓存，来避免在每次执行时，可能产生的、高性能消耗的 Babel 重新编译过程(recompilation process)。如果设置了一个空值 (`loader: 'babel-loader?cacheDirectory`) 或者 `true` (`loader: babel-loader?cacheDirectory=true`)，loader 将使用默认的缓存目录 `node_modules/.cache/babel-loader`，如果在任何根目录下都没有找到 `node_modules` 目录，将会降级回退到操作系统默认的临时文件目录。
+* `cacheIdentifier`：默认是一个由 `@babel/core` 的版本号，`babel-loader` 的版本号，`.babelrc` 文件内容（存在的情况下），环境变量 `BABEL_ENV` 的值（没有时降级到 `NODE_ENV`）组成的字符串。可以设置为一个自定义的值，在 identifier 改变后，强制缓存失效。
+* `cacheCompression`：默认值为 `true`。当有设置时，每个Babel转换输出将使用Gzip压缩。如果你想要退出缓存压缩，将它设置为 `false` -- 如果您的项目转换成数千个文件，您的项目可能会从中得到好处。
+* `customize`: 默认为 `null`。导出 `custom` 回调的文件路径，[就像(下文中)传递`.custom()`那样](#customized-loader)(相关内容见下文[自定义 loader])。由于你必须创建一个新文件才能使用它，建议你使用 `.custom` 来创建一个包装loader. 只有在你必须继续直接使用`babel-loader`但又想自定义的情况下才使用这项配置。
 
 ## 疑难解答
 
@@ -104,11 +95,11 @@ babel 对一些公共方法使用了非常小的辅助代码，比如 `_extend`�
 
 你可以引入 babel runtime 作为一个独立模块，来避免重复引入。
 
-下面的配置禁用了 babel 自动对每个文件的 runtime 注入，而是引入 `babel-plugin-transform-runtime` 并且使所有辅助代码从这里引用。
+下面的配置禁用了 babel 自动对每个文件的 runtime 注入，而是引入 `@babel/plugin-transform-runtime` 并且使所有辅助代码从这里引用。
 
 更多信息请参考[文档](http://babeljs.io/docs/plugins/transform-runtime/)。
 
-**注意：** 你必须执行 `npm install babel-plugin-transform-runtime --save-dev` 来把它包含到你的项目中，也要使用 `npm install babel-runtime --save` 把 `babel-runtime` 安装为一个依赖。
+**注意：** 你必须执行 `npm install -D @babel/plugin-transform-runtime` 来把它包含到你的项目中，也要使用 `npm install @babel/runtime` 把 `@babel/runtime` 安装为一个依赖。
 
 ```javascript
 rules: [
@@ -120,7 +111,7 @@ rules: [
       loader: 'babel-loader',
       options: {
         presets: ['@babel/preset-env'],
-        plugins: ['@babel/transform-runtime']
+        plugins: ['@babel/plugin-transform-runtime']
       }
     }
   }
@@ -129,7 +120,7 @@ rules: [
 
 #### **注意：** transform-runtime 和自定义 polyfills (比如 Promise library)
 
-由于 [babel-plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) 包含了一个 polyfill，含有自定义的 [regenerator runtime](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) 和 [core.js](https://github.com/zloirock/core-js), 下面使用 `webpack.ProvidePlugin` 来配置 shimming 的常用方法将没有作用：
+由于 [@babel/plugin-transform-runtime](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) 包含了一个 polyfill，含有自定义的 [regenerator runtime](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) 和 [core.js](https://github.com/zloirock/core-js), 下面使用 `webpack.ProvidePlugin` 来配置 shimming 的常用方法将没有作用：
 
 ```javascript
 // ...
@@ -175,7 +166,7 @@ require('./app');
 
 ### `babel` 的 node API 已经被移到 `babel-core` 中。
 
-(原文：The node API for `babel` has been moved to `babel-core`.)
+(原文：The Node.js API for `babel` has been moved to `babel-core`.)
 
 如果你收到这个信息，这说明你有一个已经安装的 `babel` 包，并且在 webpack 配置中使用它来作为 loader 的简写 (这样的方式在 webpack 2.x 版本中将不再被支持)。
 
@@ -188,7 +179,7 @@ require('./app');
 
 webpack 将尝试读取 `babel` 包而不是 `babel-loader`。
 
-要修复这个问题，你需要删除 `babel` npm 包，因为它在 babel v6 中已经被废除。(安装 `babel-cli` 或者 `babel-core` 来替代它)。
+要修复这个问题，你需要删除 `babel` npm 包，因为它在 babel v6 中已经被废除。(安装 `@babel/cli` 或者 `@babel/core` 来替代它)。
 
 如果你的依赖中有对 `babel` 包的依赖使你无法删除它，可以在 webpack 配置中使用完整的 loader 名称来解决：
 ```js
@@ -198,4 +189,91 @@ webpack 将尝试读取 `babel` 包而不是 `babel-loader`。
   }
 ```
 
-## [License](http://couto.mit-license.org/)
+## 自定义 loader
+
+`babel-loader` 提供了一个loader-builder实用程序，允许用户对"Babel处理的每个文件"添加自定义处理配置项。
+
+`.custom` 接收一个回调，它将被 `babel` 实例本身的loader调用，因此，工具能够完全确保它使用和`@babel/core` 完全相同的实例作为它自己的loader。
+
+如果你想自定义而不是调用一个名叫 `.custom` 的文件，你也可以使用某个导出了你的`custom`回调函数的文件，给 `customize` 配置传一个字符串类型的文件名称。
+
+### 示例
+
+```js
+// 从"./my-custom-loader.js"或者任何你想要的文件名导出
+module.exports = require("babel-loader").custom(babel => {
+  function myPlugin() {
+    return {
+      visitor: {},
+    };
+  }
+
+  return {
+    // 提供这个loader的配置.
+    customOptions({ opt1, opt2, ...loader }) {
+      return {
+        // loader可能具有的任何自定义配置
+        custom: { opt1, opt2 },
+
+        // "移除了两个自定义配置"的配置
+        loader,
+      };
+    },
+
+    // 提供Babel的'PartialConfig'对象
+    config(cfg) {
+      if (cfg.hasFilesystemConfig()) {
+        // 使用正常的配置
+        return cfg.options;
+      }
+
+      return {
+        ...cfg.options,
+        plugins: [
+          ...(cfg.options.plugins || []),
+
+          // 在配置中包含自定义plugin
+          myPlugin,
+        ],
+      };
+    },
+
+    result(result) {
+      return {
+        ...result,
+        code: result.code + "\n// Generated by some custom loader",
+      };
+    },
+  };
+});
+```
+
+```js
+// 然后在你的Webpack config文件中
+module.exports = {
+  // ..
+  module: {
+    rules: [{
+      // ...
+      loader: path.join(__dirname, 'my-custom-loader.js'),
+      // ...
+    }]
+  }
+};
+```
+
+### `customOptions(options: Object): { custom: Object, loader: Object }`
+
+指定的loader的配置选项，从`babel-loader`中分离出自定义选项。
+
+### `config(cfg: PartialConfig): Object`
+
+指定的Babel `PartialConfig` 对象，返回应该被传递给 `babel.transform` 的 `option` 对象。
+
+### `result(result: Result): Result`
+
+指定的Babel结果对象，允许loaders对它进行额外的调整。
+
+## License
+
+[MIT](https://couto.mit-license.org/)


### PR DESCRIPTION
Babel 已经更行至 v7，相关包名变更较大，该文档英文原文已更新，翻译还处在旧版本内容，新手在学习时会因为安装了新版本而提示警告/错误信息，无法根据文档内容继续进行。

更新了相关包名，版本号，以及添加了新特性 Customized Loader 相关内容翻译。