### PR TITLE
new CleanWebpackPlugin()引入方式更新

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -202,7 +202,7 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-+ const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
原方式
const CleanWebpackPlugin = require('clean-webpack-plugin');

module.exports = {
    ...
    plugins:[
       new CleanWebpackPlugin()
    ]
    ...
}
由于引入方式错误导致无法正常运行。
报错内容：TypeError: CleanWebpackPlugin is not a constructor
