### PR TITLE
Update style-loader.md

### DIFF
--- a/src/content/loaders/style-loader.md
+++ b/src/content/loaders/style-loader.md
@@ -65,7 +65,7 @@ import url from 'file.css';
     rules: [
       {
         test: /\.css$/,
-        use: [{ loader: 'style-loader/url' }, { loader: 'file-loader' }],
+        use: [{ loader: 'style-loader', options: { injectType: 'linkTag' } }, { loader: 'file-loader' }],
       },
     ];
   }
@@ -237,7 +237,7 @@ import link from './file.css';
 {
   test: /\.css$/,
   use: [
-    { loader: 'style-loader/url', options: { attrs: { id: 'id' } } }
+    { loader: 'style-loader', options: { injectType: 'linkTag', attrs: { id: 'id' } } }
     { loader: 'file-loader' }
   ]
 }


### PR DESCRIPTION
style-loader 生成 link 标签的 api 变了

由 ‘style-loader/url’ 变更为 配置 options: { injectType: 'linkTag' }

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
