### PR TITLE
CleanWebpackPlugin is not a constructor

### DIFF
--- a/src/content/guides/output-management.md
+++ b/src/content/guides/output-management.md
@@ -186,7 +186,7 @@ __webpack.config.js__
 ``` diff
   const path = require('path');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
-+ const CleanWebpackPlugin = require('clean-webpack-plugin');
++ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
   module.exports = {
     entry: {


### PR DESCRIPTION
CleanWebpackPlugin is not a constructor

- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
