### PR TITLE
docs(configuration): fix aggregateTimeout

### DIFF
--- a/src/content/configuration/watch.md
+++ b/src/content/configuration/watch.md
@@ -52,7 +52,7 @@ module.exports = {
 
 ## `watchOptions.aggregateTimeout`
 
-`number = 300`
+`number = 200`
 
 Add a delay before rebuilding once the first file changed. This allows webpack to aggregate any other changes made during this time period into one rebuild. Pass a value in milliseconds:
 


### PR DESCRIPTION
`watchOptions.aggregateTimeout` defalut value is `200` . 
[webpack source code](https://github.com/webpack/webpack/blob/v4.41.5/lib/Watching.js#L27)
