### PR TITLE
update a word mistake in dev-server.md

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -911,7 +911,7 @@ module.exports = {
 };
 ```
 
-注意，默认情况下，根请求不会被代理。要启用根代理，应该将 `devServer.index` 选项指定为 falsy 值：
+注意，默认情况下，根请求不会被代理。要启用根代理，应该将 `devServer.index` 选项指定为 false 值：
 
 __webpack.config.js__
 


### PR DESCRIPTION
There is a word mistake in line 914 of the file dev-server.md, which  spell the word false to falsy by mistake.

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
